### PR TITLE
Bump ghq version to 1.1.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-ghq_repository: github.com/motemen/ghq
+ghq_repository: github.com/x-motemen/ghq
 ghq_archive_ext: zip
 ghq_install_dir: /usr/local/bin
-ghq_version: 1.0.1
+ghq_version: 1.1.0
 
 # Install ghq by Homebrew on macOS
 ghq_install_by_brew: no

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,7 +14,7 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python36 sudo python36-devel python3-dnf bash iproute && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \


### PR DESCRIPTION
### Changes

- Use github.com/x-motemen/ghq instead of github.com/motemen/ghq
- Update default version from 1.0.1 to 1.1.0